### PR TITLE
Old thumbnails when reloading the VideoJS player and thumbnail plugin for an other video

### DIFF
--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -28,7 +28,7 @@
    */
   videojs.plugin('thumbnails', function(options) {
     var div, settings, img, player, progressControl, duration;
-    settings = extend(defaults, options);
+    settings = extend({}, defaults, options);
     player = this;
 
     // create the thumbnail


### PR DESCRIPTION
When reloading the VideoJS player and then the thumbnail plugin  for an other video (through an AJAX request for instance), without reloading the scripts, old values for the thumbnails are kept for the new video because they are stored in the `default` object:

```
settings = extend(defaults, options);
```

This will copy the `options` properties to `defaults` and then returns `defaults`.

Extending from a empty `{}` object fixes the issue: this will ensure we always have a new `settings` object that's never `defaults`.
