### PR TITLE
use pageXOffset instead of screenX so the thumbs move in IE

### DIFF
--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -65,7 +65,7 @@
       // find the page offset of the mouse
       left = event.pageX || (event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft);
       // subtract the page offset of the progress control
-      left -= progressControl.el().getBoundingClientRect().left + window.scrollX;
+      left -= progressControl.el().getBoundingClientRect().left + window.pageXOffset;
       div.style.left = left + 'px';
 
       // apply updated styles to the thumbnail if necessary


### PR DESCRIPTION
I guess screenX isn't supported in IE, so left gets assigned to NaN. Use pageXOffset to work around this issue
