### PR TITLE
move the placeholder out of the way when the thumb isn't shown 

### DIFF
--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -83,5 +83,10 @@
         extend(img.style, setting.style);
       }
     }, false);
+    
+    // move the placeholder out of the way when not hovering
+    progressControl.el().addEventListener('mouseout', function(event) {
+      div.style.left = '-1000px';
+    }, false);
   });
 })();


### PR DESCRIPTION
Move the placeholder when it's not visible so it doesn't block clicks on other elements.
