### PR TITLE
Offsetparent

### DIFF
--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -98,10 +98,13 @@
         extend(img.style, setting.style);
       }
     }, false);
-    
+
     // move the placeholder out of the way when not hovering
     progressControl.el().addEventListener('mouseout', function(event) {
       div.style.left = '-1000px';
     }, false);
+    player.on('userinactive', function(event) {
+      div.style.left = '-1000px';
+    });
   });
 })();


### PR DESCRIPTION
The `left` offset calculations for the thumbnail div was incorrectly assuming the progress control was the positioned element we should be calculating against. This finds the proper offset parent.

It also hides thumbnails on user inactivity.
