### PR TITLE
use offset parent "width" rather than "right".

### DIFF
--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -112,7 +112,7 @@
       var mouseTime, time, active, left, setting, pageX, right, width, halfWidth;
       active = 0;
 
-      right = offsetParent(progressControl.el()).getBoundingClientRect().right + window.pageXOffset;
+      right = offsetParent(progressControl.el()).getBoundingClientRect().width + window.pageXOffset;
 
       pageX = event.pageX;
       if (event.changedTouches) {


### PR DESCRIPTION
This is because the `right` ends up being the wrong value for us.
It ends up being the right side of the iframe if we are pillarboxed. `width` works with both pillar- and letter-boxing.
