### PR TITLE
Make sure that clip is a shape

### DIFF
--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -45,7 +45,7 @@
       }
 
       clip = getComputedStyle(el)('clip');
-      if (clip) {
+      if (clip !== 'auto' && clip !== 'inherit') {
         clip = clip.split(/(?:\(|\))/)[1].split(/(?:,| )/);
         if (clip.length === 4) {
           return (parseFloat(clip[1]) - parseFloat(clip[3]));


### PR DESCRIPTION
`clip` is either a `shape` of the form `rect(top, right, bottom, left)` or `auto` or `inherit`. Make sure that it's in `shape` form before trying to split it.
