### PR TITLE
Adding support to HLS container

### DIFF
--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -112,7 +112,14 @@
 
     // keep track of the duration to calculate correct thumbnail to display
     duration = player.duration();
+    
+    // when the container is MP4
     player.on('durationchange', function(event) {
+      duration = player.duration();
+    });
+
+    // when the container is HLS
+    player.on('loadedmetadata', function(event) {
       duration = player.duration();
     });
 


### PR DESCRIPTION
For some reason, durationchange doesn't work when the container is HLS/Flash. The first thumbnail is showing but isn't updating on any browser when the mouse hovers over the scrubber. 

Not sure if HLS should fire an event on duration but in the meantime, this does the trick.
