### PR TITLE
mouseTime fix

### DIFF
--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -149,7 +149,10 @@
       // `left` applies to the mouse position relative to the player so we need
       // to remove the progress control's left offset to know the mouse position
       // relative to the progress control
-      mouseTime = Math.floor((left - progressControl.el().offsetLeft) / progressControl.width() * duration);
+      var el = progressControl.el();
+      var boxX = el.getBoundingClientRect().left + (window.pageXOffset || document.body.scrollLeft) - (document.documentElement.clientLeft || document.body.clientLeft || 0);
+      mouseTime = Math.floor(Math.max(0, Math.min(1, (pageX - boxX) / el.offsetWidth)) * duration);
+
       for (time in settings) {
         if (mouseTime > time) {
           active = Math.max(active, time);


### PR DESCRIPTION
This fixes the mouseTime, which is currently sometimes wrong. With the current video.js default skin, there is an offset in time due to the volume control sometimes taking the space. The code I'm using is taken from the core of video.js:

https://github.com/videojs/video.js/pull/2569/files#diff-be82dd77ef994b77f1636de6ed9d2c59R45
https://github.com/videojs/video.js/blob/master/src/js/utils/dom.js#L473