### PR TITLE
Corrected Time calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "type": "git",
     "url": "git@github.com:brightcove/videojs-thumbnails.git"
   },
+  "main": "./videojs.thumbnails.js",
+  "style": "./videojs.thumbnails.css",
   "version": "0.1.1",
   "devDependencies": {
     "grunt": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "type": "git",
     "url": "git@github.com:brightcove/videojs-thumbnails.git"
   },
-  "main": "./videojs.thumbnails.js",
-  "style": "./videojs.thumbnails.css",
-  "version": "0.1.1",
+  "main": "videojs.thumbnails.js",
+  "style": "videojs.thumbnails.css",
+  "version": "0.1.2",
   "devDependencies": {
     "grunt": "^0.4.4",
     "grunt-contrib-connect": "^0.9.0",

--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -1,4 +1,4 @@
-import videojs from 'video.js';
+import videojs from 'videojs';
 
 (function() {
   var defaults = {

--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -127,7 +127,7 @@ import videojs from 'videojs';
 
     // add the thumbnail to the player
     progressControl = player.controlBar.progressControl;
-    progressControl.el().appendChild(div);
+    player.controlBar.el().appendChild(div);
 
     // find the proper element to use for time calculations
     var eleForTime;
@@ -186,6 +186,7 @@ import videojs from 'videojs';
       }
 
       div.style.left = left + 'px';
+      div.style.display = 'block';
     };
 
     // update the thumbnail while hovering
@@ -194,6 +195,7 @@ import videojs from 'videojs';
 
     moveCancel = function(event) {
       div.style.left = '-1000px';
+      div.style.display = 'none';
     };
 
     // move the placeholder out of the way when not hovering

--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -127,6 +127,16 @@
     progressControl = player.controlBar.progressControl;
     progressControl.el().appendChild(div);
 
+    // find the proper element to use for time calculations
+    var eleForTime;
+    for( var e in progressControl.el().childNodes ) {
+      var childNode = progressControl.el().childNodes[e];
+      if( childNode.className.indexOf('vjs-progress-holder') >= 0 ) {
+        eleForTime = childNode;
+        break;
+      }
+    }
+
     moveListener = function(event) {
       var mouseTime, time, active, left, setting, pageX, right, width, halfWidth, pageXOffset, clientRect;
       active = 0;
@@ -142,16 +152,16 @@
       // find the page offset of the mouse
       left = pageX || (event.clientX + document.body.scrollLeft + document.documentElement.scrollLeft);
       // subtract the page offset of the positioned offset parent
-      left -= offsetParent(progressControl.el()).getBoundingClientRect().left + pageXOffset;
+      left -= eleForTime.getBoundingClientRect().left + pageXOffset;
 
       // apply updated styles to the thumbnail if necessary
       // mouseTime is the position of the mouse along the progress control bar
       // `left` applies to the mouse position relative to the player so we need
       // to remove the progress control's left offset to know the mouse position
       // relative to the progress control
-      mouseTime = Math.floor((left - progressControl.el().offsetLeft) / progressControl.width() * duration);
+      mouseTime = left / eleForTime.getBoundingClientRect().width * duration;
       for (time in settings) {
-        if (mouseTime > time) {
+        if (mouseTime >= time) {
           active = Math.max(active, time);
         }
       }

--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -1,4 +1,4 @@
-import videojs from 'videojs/video.js';
+import videojs from 'video.js';
 
 (function() {
   var defaults = {

--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -1,3 +1,5 @@
+import videojs from 'videojs/video.js';
+
 (function() {
   var defaults = {
       0: {


### PR DESCRIPTION
After looking at how the videojs player did its time calculations, I noticed that this plugin's times were off depending on the size of the window the player is in.  I was able to correct this by using the same DOM element that the player was using.
