### PR TITLE
Fix the calculation of mouseTime

### DIFF
--- a/videojs.thumbnails.js
+++ b/videojs.thumbnails.js
@@ -146,10 +146,8 @@
 
       // apply updated styles to the thumbnail if necessary
       // mouseTime is the position of the mouse along the progress control bar
-      // `left` applies to the mouse position relative to the player so we need
-      // to remove the progress control's left offset to know the mouse position
-      // relative to the progress control
-      mouseTime = Math.floor((left - progressControl.el().offsetLeft) / progressControl.width() * duration);
+      // `left` applies to the mouse position relative to the progress control
+      mouseTime = Math.floor(left / progressControl.width() * duration);
       for (time in settings) {
         if (mouseTime > time) {
           active = Math.max(active, time);


### PR DESCRIPTION
When testing with the latest video.js and browsers, the original calculation returns negative values for "mouseTime". Variable "left" has already considered the offset thing. Removing the offset perfectly fixed the problem and the time is then correct.